### PR TITLE
remove option "com.docker.network.bridge.name" when creating network …

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ create_docker_network() {
   esac
 
   log Create host-accessible network
-  docker network create -o com.docker.network.bridge.name=$netintf $network
+  docker network create $network
 }
 
 bridge_docker_network() {


### PR DESCRIPTION
…otherwise docker-compose gives the following error when starting <ERROR: Network "docker_default" needs to be recreated - option "com.docker.network.bridge.name" has changed> (Version 17.06.0-ce-mac19)